### PR TITLE
[fix] Items from entry_maker are missing filename

### DIFF
--- a/lua/telescope/_extensions/ag.lua
+++ b/lua/telescope/_extensions/ag.lua
@@ -29,6 +29,7 @@ function M.ag(text_to_find)
 					end
 				end,
 				ordinal = rel_filepath,
+                                filename= rel_filepath,
 				path = abs_filepath,
 				lnum = line_num,
 			}

--- a/lua/telescope/_extensions/ag.lua
+++ b/lua/telescope/_extensions/ag.lua
@@ -29,7 +29,7 @@ function M.ag(text_to_find)
 					end
 				end,
 				ordinal = rel_filepath,
-                                filename= rel_filepath,
+                                filename = rel_filepath,
 				path = abs_filepath,
 				lnum = line_num,
 			}


### PR DESCRIPTION
The items in entry_maker are missing filename. This is causing errors when the entries are piped to trouble.nvim.

----

There are multiple examples of filename usage in telescope, I learned usage from there. [Ex:1](https://github.com/nvim-telescope/telescope.nvim/blob/8d1841bff5c70d05f458ded09e465ae4ac21ecce/lua/telescope/builtin/internal.lua#L447), [Ex:2](https://github.com/nvim-telescope/telescope.nvim/blob/8d1841bff5c70d05f458ded09e465ae4ac21ecce/lua/telescope/builtin/internal.lua#L710). [Ex:3](https://github.com/nvim-telescope/telescope.nvim/blob/8d1841bff5c70d05f458ded09e465ae4ac21ecce/lua/telescope/builtin/internal.lua#L1284)

----

The trouble.nvim is expecting the filename [here](https://github.com/folke/trouble.nvim/blob/main/lua/trouble/providers/telescope.lua#L13). And, is failing at `vim.fn.bufnr(item.filename, true)`